### PR TITLE
Prevent zero compounding wins crash

### DIFF
--- a/Include/ACFunctions.mqh
+++ b/Include/ACFunctions.mqh
@@ -40,10 +40,22 @@ datetime lastProcessedDealTime = 0;   // Time stamp to avoid reprocessing old cl
 //+------------------------------------------------------------------+
 //| Update risk based on trade result - with profit parameter        |
 //+------------------------------------------------------------------+
+void EnsureValidCompoundingWins()
+{
+   if(AC_CompoundingWins <= 0)
+   {
+      int fallbackValue = (AC_CompoundingWins_Input > 0) ? AC_CompoundingWins_Input : 1;
+      AC_CompoundingWins = fallbackValue;
+      Print("WARNING: AC_CompoundingWins was zero or negative. Using fallback value of ", AC_CompoundingWins, ".");
+   }
+}
+
 void UpdateRiskBasedOnResultWithProfit(bool isWin, int magic, double profit)
 {
+   EnsureValidCompoundingWins();
+
    double currentEquity = AccountInfoDouble(ACCOUNT_EQUITY);
-   
+
    if(isWin)
    {
       // Calculate position in cycle (0-based index)


### PR DESCRIPTION
## Summary
- guard the risk management routine against zero or negative compounding win settings
- fall back to a sane minimum value and log a warning before performing cycle math

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db10f491c8832889805cfeaef08c08